### PR TITLE
Fix Railway config: remove buildCommand

### DIFF
--- a/railway.toml
+++ b/railway.toml
@@ -1,5 +1,2 @@
-[build]
-buildCommand = "npm run install-backend"
-
 [deploy]
 startCommand = "npm start"


### PR DESCRIPTION
- Railway auto-installs dependencies when it detects package.json
- Only need startCommand to run the server
- Fixes 'buildCommand and startCommand cannot be the same' error