### PR TITLE
Fix Railway build: use postinstall instead of custom script

### DIFF
--- a/backend/Procfile
+++ b/backend/Procfile
@@ -1,1 +1,0 @@
-web: npm start

--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "description": "Card Organizer - Netlify Frontend + Railway Backend",
   "private": true,
   "scripts": {
-    "start": "cd backend && npm start",
-    "install-backend": "cd backend && npm install"
+    "postinstall": "cd backend && npm install",
+    "start": "cd backend && npm start"
   },
   "engines": {
     "node": ">=18.0.0"


### PR DESCRIPTION
- Changed install-backend to postinstall (runs automatically after npm ci)
- Removed Procfile to avoid conflicts with railway.toml
- Railway will now: npm ci → postinstall (installs backend deps) → npm start
- Fixes 'Missing script: install-backend' error