### PR TITLE
Fix horizontal card flip direction to open right-to-left

### DIFF
--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -368,7 +368,7 @@ textarea {
 
 /* Flipped states for different orientations */
 .card-flipper.flipped-horizontal {
-  transform: rotateY(180deg);
+  transform: rotateY(-180deg);
 }
 
 .card-flipper.flipped-vertical {
@@ -394,7 +394,7 @@ textarea {
 
 /* Back face - rotated 180 degrees to show on flip */
 .card-back.horizontal {
-  transform: rotateY(180deg);
+  transform: rotateY(-180deg);
 }
 
 .card-back.vertical {


### PR DESCRIPTION
Change the horizontal (book-style) flip to rotate from right to left instead of left to right, which feels more natural when opening a book from the spine.

Changed rotateY from 180deg to -180deg for both the flipper transform and the back face initial position.