### PR TITLE
Fix 'To' field to support existing cards without breaking

### DIFF
--- a/backend/models/Card.js
+++ b/backend/models/Card.js
@@ -4,7 +4,7 @@ const mongoose = require("mongoose");
 const cardSchema = new mongoose.Schema({
   title: { type: String, required: true },
   from: { type: String, required: true },
-  to: { type: String, required: true },
+  to: { type: String, default: "" }, // Optional, for backward compatibility with existing cards
   occasion: { type: String, default: "Miscellaneous" },
   pages: { type: [String], required: true }, // Array of image URLs or paths
   flipOrientation: { type: String, default: "horizontal" }, // Orientation of the card

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -241,7 +241,7 @@ async function getCards(resetFilters = false) {
       cardElement.innerHTML = `
         <h3>${card.title}</h3>
         <p><strong>From:</strong> ${card.from}</p>
-        <p><strong>To:</strong> ${card.to}</p>
+        <p><strong>To:</strong> ${card.to || 'Not specified'}</p>
         <p><strong>Occasion:</strong> ${card.occasion}</p>
         <div class="pages">
           <img src="${getImageUrl(card.pages[0])}" alt="Card page" style="width: 100%; height: 150px; object-fit: cover; border-radius: 10px;"/>
@@ -256,7 +256,7 @@ async function getCards(resetFilters = false) {
 
       allOccasions.add(card.occasion);
       allFroms.add(card.from);
-      allTos.add(card.to);
+      if (card.to) allTos.add(card.to); // Only add non-empty "to" values
     });
 
     updateFilters();
@@ -394,7 +394,7 @@ function viewCard(cardId) {
 
   document.getElementById('viewTitle').innerText = card.title;
   document.getElementById('viewFrom').innerText = card.from;
-  document.getElementById('viewTo').innerText = card.to;
+  document.getElementById('viewTo').innerText = card.to || 'Not specified';
   document.getElementById('viewOccasion').innerText = card.occasion;
 
   const viewNoteButton = document.getElementById('viewNoteButton');
@@ -484,7 +484,7 @@ function editCard(cardId) {
 
   document.getElementById('editTitle').value = card.title;
   document.getElementById('editFrom').value = card.from;
-  document.getElementById('editTo').value = card.to;
+  document.getElementById('editTo').value = card.to || '';
   document.getElementById('editOccasion').value = card.occasion;
   document.getElementById('editFlipOrientation').value = card.flipOrientation;
   document.getElementById('editNote').value = card.note || '';


### PR DESCRIPTION
- Made 'to' field optional with empty string default for backward compatibility
- Added fallback display ('Not specified') for cards without 'to' value
- Only populate 'To' filter dropdown with non-empty values
- Frontend still requires 'to' for new cards through UI validation
- Existing cards without 'to' field will now load and display properly