### PR TITLE
Fix autocomplete initialization error in edit modal

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -136,12 +136,13 @@ function createTagInput(containerId, field, initialTags = []) {
     }
   });
 
-  // Initialize autocomplete for this input
+  // Append input to container first
+  container.appendChild(input);
+
+  // Initialize autocomplete for this input (after appending to DOM)
   if (field === 'from' || field === 'to') {
     initializeAutocomplete(input, field);
   }
-
-  container.appendChild(input);
 }
 
 // Add a tag chip to the container


### PR DESCRIPTION
- Moved input.appendChild() before initializeAutocomplete() call
- Ensures input element is in DOM before autocomplete tries to access parentElement
- Fixes 'TypeError: null is not an object (evaluating container.style)' error