### PR TITLE
Add proper spacing for form labels in add/edit modals

### DIFF
--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -664,6 +664,15 @@ textarea {
   margin-top: 20px;
 }
 
+.card-form label {
+  display: block;
+  margin-top: 15px;
+  margin-bottom: 5px;
+  font-weight: 600;
+  color: #333;
+  text-align: left;
+}
+
 .checkbox-container {
   text-align: left;
   margin: 15px 0;


### PR DESCRIPTION
- Labels now display as block elements on their own line
- Added top/bottom margins for better visual separation
- Made labels bold and left-aligned for clarity
- Prevents 'From (senders):' from appearing on same line as title