### PR TITLE
Fix orange gradient not displaying on mobile devices

### DIFF
--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -5,9 +5,15 @@
   box-sizing: border-box;
 }
 
+html {
+  min-height: 100%;
+  background: linear-gradient(135deg, #ff7e5f 0%, #feb47b 100%);
+  background-attachment: fixed;
+}
+
 body {
   font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
-  background: linear-gradient(135deg, #ff7e5f 0%, #feb47b 100%);
+  background: transparent;
   min-height: 100vh;
   color: #333;
 }


### PR DESCRIPTION
- Moved background gradient from body to html element
- Added background-attachment: fixed to keep gradient visible
- Set body background to transparent to show html gradient
- Ensures orange theme displays consistently on mobile and desktop