### PR TITLE
Add pagination support to display more cards

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -133,12 +133,23 @@ app.get("/cards", authMiddleware, async (req, res) => {
   }
 
   try {
+    // Get total count for pagination
+    const totalCards = await Card.countDocuments(query);
+
     const cards = await Card.find(query)
       .sort(sort === 'newest' ? { upload_date: -1 } : { upload_date: 1 })
       .skip((page - 1) * limit)
       .limit(Number(limit));
 
-    res.json(cards);
+    res.json({
+      cards,
+      pagination: {
+        currentPage: Number(page),
+        totalPages: Math.ceil(totalCards / limit),
+        totalCards,
+        cardsPerPage: Number(limit)
+      }
+    });
   } catch (err) {
     res.status(500).json({ message: "Error fetching cards", error: err });
   }

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -4,7 +4,8 @@ let currentUser = null;
 
 // Card State
 let currentPage = 1;
-const cardsPerPage = 10;
+let totalPages = 1;
+const cardsPerPage = 20;
 let allCards = [];
 let allOccasions = new Set();
 let allFroms = new Set();
@@ -474,6 +475,12 @@ function logout(showAlert = true) {
   showUnauthenticatedView();
 }
 
+// Apply filters and reset to page 1
+function applyFilters() {
+  currentPage = 1;
+  getCards();
+}
+
 // Function to Fetch and Display All Cards
 async function getCards(resetFilters = false) {
   if (!authToken) {
@@ -514,12 +521,19 @@ async function getCards(resetFilters = false) {
       return;
     }
 
-    allCards = await response.json();
+    const data = await response.json();
+    allCards = data.cards || [];
+    const pagination = data.pagination || { currentPage: 1, totalPages: 1, totalCards: 0 };
+
+    totalPages = pagination.totalPages;
+    currentPage = pagination.currentPage;
+
     const cardsDiv = document.getElementById("cards");
     cardsDiv.innerHTML = "";
 
     if (allCards.length === 0) {
       cardsDiv.innerHTML = '<p style="text-align: center; color: #999; grid-column: 1/-1;">No cards found. Click "Add Card" to create your first card!</p>';
+      updatePaginationControls();
       return;
     }
 
@@ -559,10 +573,48 @@ async function getCards(resetFilters = false) {
     });
 
     updateFilters();
+    updatePaginationControls();
   } catch (error) {
     console.error("Error fetching cards:", error);
     alert('Error loading cards. Please try again.');
   }
+}
+
+// Update pagination controls
+function updatePaginationControls() {
+  const paginationDiv = document.getElementById('paginationControls');
+  if (!paginationDiv) return;
+
+  // Hide pagination if only one page
+  if (totalPages <= 1) {
+    paginationDiv.style.display = 'none';
+    return;
+  }
+
+  paginationDiv.style.display = 'flex';
+
+  const prevButton = currentPage > 1
+    ? `<button class="btn-secondary" onclick="changePage(${currentPage - 1})">← Previous</button>`
+    : `<button class="btn-secondary" disabled>← Previous</button>`;
+
+  const nextButton = currentPage < totalPages
+    ? `<button class="btn-secondary" onclick="changePage(${currentPage + 1})">Next →</button>`
+    : `<button class="btn-secondary" disabled>Next →</button>`;
+
+  paginationDiv.innerHTML = `
+    ${prevButton}
+    <span class="page-info">Page ${currentPage} of ${totalPages}</span>
+    ${nextButton}
+  `;
+}
+
+// Navigate to a specific page
+function changePage(page) {
+  if (page < 1 || page > totalPages) return;
+  currentPage = page;
+  getCards();
+  // Scroll to top of cards section
+  document.getElementById('cards').scrollIntoView({ behavior: 'smooth' });
 }
 
 // Function to Update All Filters

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -45,25 +45,25 @@
         <span id="filterToggleIcon" class="toggle-icon">▼</span>
       </h2>
       <div id="filtersContainer" class="filters-container" style="display: none;">
-        <select id="occasionFilter" onchange="getCards()">
+        <select id="occasionFilter" onchange="applyFilters()">
           <option value="">All Occasions</option>
         </select>
 
-        <select id="fromFilter" onchange="getCards()">
+        <select id="fromFilter" onchange="applyFilters()">
           <option value="">All Senders</option>
         </select>
 
-        <select id="toFilter" onchange="getCards()">
+        <select id="toFilter" onchange="applyFilters()">
           <option value="">All Recipients</option>
         </select>
 
-        <select id="sortOrder" onchange="getCards()">
+        <select id="sortOrder" onchange="applyFilters()">
           <option value="newest">Newest First</option>
           <option value="oldest">Oldest First</option>
         </select>
 
         <input type="text" id="searchQuery" placeholder="Search cards..." />
-        <button class="btn-primary" onclick="getCards()">Search</button>
+        <button class="btn-primary" onclick="applyFilters()">Search</button>
         <button class="btn-secondary" onclick="getCards(true)">Refresh</button>
       </div>
     </div>
@@ -71,6 +71,7 @@
     <!-- Display All Cards -->
     <div class="cards-section">
       <div id="cards"></div>
+      <div id="paginationControls" class="pagination-controls"></div>
     </div>
   </div>
 

--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -665,6 +665,35 @@ textarea {
   text-decoration: underline;
 }
 
+/* Pagination Controls */
+.pagination-controls {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: 20px;
+  margin: 30px 0;
+  padding: 20px;
+}
+
+.pagination-controls button {
+  min-width: 120px;
+}
+
+.pagination-controls button:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.page-info {
+  font-size: 1.1em;
+  font-weight: 600;
+  color: #333;
+  background: rgba(255, 255, 255, 0.9);
+  padding: 10px 20px;
+  border-radius: 10px;
+  box-shadow: 0 2px 5px rgba(0, 0, 0, 0.1);
+}
+
 /* Card Form Styles */
 .card-form {
   margin-top: 20px;


### PR DESCRIPTION
Backend changes:
- Updated /cards endpoint to return pagination metadata
- Includes currentPage, totalPages, totalCards, cardsPerPage
- Uses countDocuments() to calculate total pages

Frontend changes:
- Increased cardsPerPage from 10 to 20 cards
- Added pagination controls (Previous/Next buttons, page indicator)
- Created applyFilters() to reset to page 1 when filters change
- Created changePage() to navigate between pages
- Added updatePaginationControls() to show/hide pagination UI
- Pagination scrolls to top of cards for better UX

UI changes:
- Added pagination controls div below cards grid
- Styled pagination with orange theme buttons
- Disabled buttons show reduced opacity
- Page info displayed in centered badge

Users can now see 20 cards per page and navigate through all their cards.