### PR TITLE
Make email whitelist mandatory for registration

### DIFF
--- a/backend/routes/auth.js
+++ b/backend/routes/auth.js
@@ -11,11 +11,10 @@ function isEmailWhitelisted(email) {
   // Get allowed emails from environment variable
   const allowedEmails = process.env.ALLOWED_EMAILS || '';
 
-  // If no whitelist is set, allow all (for development/testing)
-  // Remove this check if you want to require a whitelist
+  // If no whitelist is set, block all registrations
   if (!allowedEmails) {
-    console.warn('WARNING: No ALLOWED_EMAILS whitelist configured. All emails are allowed.');
-    return true;
+    console.error('ERROR: No ALLOWED_EMAILS whitelist configured. All registrations blocked.');
+    return false;
   }
 
   // Split by comma and trim whitespace


### PR DESCRIPTION
- Changed behavior to block ALL registrations when ALLOWED_EMAILS is not set
- Returns false instead of true when whitelist is empty
- Logs error instead of warning when no whitelist configured
- Prevents unauthorized account creation even in development