### PR TITLE
Raise max pages per card from 5 to 20

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -226,7 +226,7 @@ app.get("/autocomplete/:field", authMiddleware, async (req, res) => {
 
 // API to upload card data (protected)
 app.post("/upload", authMiddleware, uploadLimiter, (req, res, next) => {
-  upload.array("pages", 5)(req, res, (err) => {
+  upload.array("pages", 20)(req, res, (err) => {
     if (err) {
       return res.status(400).json({ message: "File upload failed", error: err.message });
     }

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -703,6 +703,11 @@ async function addCard() {
     return;
   }
 
+  if (pagesInput.files.length > 20) {
+    alert("You can upload a maximum of 20 images per card.");
+    return;
+  }
+
   const formData = new FormData();
   formData.append("title", title);
   formData.append("from", JSON.stringify(fromTags));


### PR DESCRIPTION
The previous limit of 5 was too restrictive — users with multi-page cards were hitting "File upload failed" from multer rejecting the extra files. Added a matching frontend guard that shows a clear message before the request is even sent.

https://claude.ai/code/session_013h5bW4zjzcREjR1fxkjE6R